### PR TITLE
Improve heapdict.py

### DIFF
--- a/heapdict.py
+++ b/heapdict.py
@@ -12,12 +12,6 @@ def doc(s):
     return f
 
 
-def _swap(arr, i, j):
-    arr[i], arr[j] = arr[j], arr[i]
-    arr[i][2] = i
-    arr[j][2] = j
-
-
 def _set(arr, i, item):
     arr[i] = item
     item[2] = i
@@ -27,28 +21,43 @@ def heappush(heap, item):
     """Push item onto heap, maintaining the heap invariant."""
     item[2] = len(heap)
     heap.append(item)
-    _siftdown(heap, 0, len(heap) - 1)
+    _siftdown(heap, item[2])
 
 
-def heappop(heap):
-    """Pop the smallest item off the heap, maintaining the heap invariant."""
-    lastelt = heap.pop()  # raises appropriate IndexError if heap is empty
-    if heap:
-        returnitem = heap[0]
-        _set(heap, 0, lastelt)
-        _siftup(heap, 0)
-        return returnitem
-    return lastelt
+def heappop(heap, i=0):
+    """Pop an item off the heap, maintaining the heap invariant."""
+    returnitem = heap[i]  # raises appropriate IndexError if invalid index.
+    lastelt = heap.pop()
+    # If we are not returning the last node, put it at i and sift it into place.
+    if lastlt is not returnitem:
+        _set(heap, i, lastelt)
+        # if lastelt is greater than the previous node, move it down.
+        if lastelt[0] > returnitem[0]:
+            _siftup(heap, i)
+        # if lastelt is smaller than the previous node, move it up.
+        elif lastelt[0] < returnitem[0]:
+            _siftdown(heap, i)
+    return returnitem
 
 
-# 'heap' is a heap at all indices >= startpos, except possibly for pos.  pos
-# is the index of a leaf with a possibly out-of-order value.  Restore the
-# heap invariant.
-def _siftdown(heap, startpos, pos):
+def heapify(heap):
+    """Transform list into a heap, in-place, in O(len(heap)) time."""
+    # Transform bottom-up.  The largest index there's any point to looking at
+    # is the largest with a child index in-range, so must have 2*i + 1 < n,
+    # or i < (n-1)/2.  If n is even = 2*j, this is (2*j-1)/2 = j-1/2 so
+    # j-1 is the largest, which is n//2 - 1.  If n is odd = 2*j+1, this is
+    # (2*j+1-1)/2 = j so j-1 is the largest, and that's again n//2-1.
+    for i in xrange(len(heap)//2 - 1, -1, -1):
+        _siftup(heap, i)
+
+
+# 'heap' is a heap at all indices < pos. 'pos' is the index of a node that may
+# need to be moved up. Shift the node at pos up to restore the heap invariant.
+def _siftdown(heap, pos):
     newitem = heap[pos]
     # Follow the path to the root, moving parents down until finding a place
     # newitem fits.
-    while pos > startpos:
+    while pos > 0:
         parentpos = (pos - 1) >> 1
         parent = heap[parentpos]
         if newitem[0] < parent[0]:
@@ -58,30 +67,31 @@ def _siftdown(heap, startpos, pos):
         break
     _set(heap, pos, newitem)
 
-
+# 'heap' is a heap at all indicies > pos. 'pos' is the index of a node that may
+# need to be moved down. Shift the entry at pos down to restore the heap invariant.
 def _siftup(heap, pos):
     endpos = len(heap)
-    startpos = pos
     newitem = heap[pos]
-    # Bubble up the smaller child until hitting a leaf.
+    # Bubble up the smaller child until we find the right position.
     childpos = 2 * pos + 1  # leftmost child position
     while childpos < endpos:
         # Set childpos to index of smaller child.
         rightpos = childpos + 1
-        if rightpos < endpos and not heap[childpos][0] < heap[rightpos][0]:
+        if rightpos < endpos and heap[childpos][0] > heap[rightpos][0]:
             childpos = rightpos
-        # Move the smaller child up.
-        _set(heap, pos, heap[childpos])
-        pos = childpos
-        childpos = 2 * pos + 1
-    # The leaf at pos is empty now.  Put newitem there, and bubble it up
-    # to its final resting place (by sifting its parents down).
+        child = heap[childpos]
+        if newitem[0] > child[0]:
+            # Move the smaller child up.
+            _set(heap, pos, child)
+            pos = childpos
+            childpos = 2 * pos + 1
+            continue
+        break
+    # The node at pos is empty now, put newitem there.
     _set(heap, pos, newitem)
-    _siftdown(heap, startpos, pos)
 
 
 class heapdict(collections.MutableMapping):
-    __marker = object()
 
     def _check_invariants(self):
         # the 3rd entry of each heap entry is the position in the heap
@@ -93,9 +103,9 @@ class heapdict(collections.MutableMapping):
             assert self.heap[parent][0] <= self.heap[i][0]
 
     def __init__(self, *args, **kw):
-        self.heap = []
-        self.d = {}
-        self.update(*args, **kw)
+        self.d = dict(*args, **kw)
+        self.heap = [[v, k, i] for (i, (k, v)) in enumerate(self.d.iteritems())]
+        heapify(self.heap)
 
     @doc(dict.clear)
     def clear(self):
@@ -104,23 +114,23 @@ class heapdict(collections.MutableMapping):
 
     @doc(dict.__setitem__)
     def __setitem__(self, key, value):
-        if key in self.d:
-            del self[key]
-        wrapper = [value, key, -2]
-        self.d[key] = wrapper
-        heappush(self.heap, wrapper)
+        try:
+            wrapper = self.d[key]
+            oldvalue, _, i = wrapper
+            wrapper[0] = value
+            if oldvalue < value:
+                _siftup(self.heap, i)
+            elif value < oldvalue:
+                _siftdown(self.heap, i)
+        except KeyError:
+            wrapper = [value, key, -2]
+            self.d[key] = wrapper
+            heappush(self.heap, wrapper)
 
     @doc(dict.__delitem__)
     def __delitem__(self, key):
-        wrapper = self.d[key]
-        i = wrapper[2]
-        lastindex = len(self.heap) - 1
-        # swap with last item
-        _swap(self.heap, i, lastindex)
-        self.heap.pop()
-        if self.heap and i < lastindex:
-            _siftup(self.heap, i)
-            _siftdown(self.heap, 0, i)
+        i = self.d[key][2]
+        heappop(self.heap, i)
         del self.d[key]
 
     @doc(dict.__getitem__)
@@ -131,6 +141,10 @@ class heapdict(collections.MutableMapping):
     def __iter__(self):
         return iter(self.d)
 
+    @doc(dict.__len__)
+    def __len__(self):
+        return len(self.d)
+
     def pop(self, *args):
         """D.pop([k,[,d]]) -> v, if no key is specified, remove the key with the lowest
 value and return the corresponding value, raising IndexError if list is empty.
@@ -138,26 +152,20 @@ If a key is specified, then it is removed instead if present and the
 corresponding value is returned. If the key is specified and not present, then
 d is returned if given, otherwise KeyError is raised"""
         if len(args) == 0:
-            if len(self.d) == 0:
-                raise IndexError("pop from empty heapdict")
-            (k, _) = self.popitem()
+            return self.popitem()[0]
         else:
-            k = super(heapdict, self).pop(*args)
-        return k
+            return = super(heapdict, self).pop(*args)
 
     def popitem(self):
         """D.popitem() -> (k, v), remove and return the (key, value) pair with lowest\nvalue; but raise KeyError if D is empty."""
         wrapper = heappop(self.heap)
         del self.d[wrapper[1]]
-        return wrapper[1], wrapper[0]
-
-    @doc(dict.__len__)
-    def __len__(self):
-        return len(self.d)
+        return (wrapper[1], wrapper[0])
 
     def peekitem(self):
         """D.peekitem() -> (k, v), return the (key, value) pair with lowest value;\n but raise KeyError if D is empty."""
-        return (self.heap[0][1], self.heap[0][0])
+        wrapper = self.heap[0]
+        return (wrapper[1], wrapper[0])
 
 
 del doc

--- a/heapdict.py
+++ b/heapdict.py
@@ -103,6 +103,7 @@ class heapdict(collections.MutableMapping):
     def __init__(self, *args, **kw):
         self.d = dict(*args, **kw)
         self.heap = [[v, k, i] for (i, (k, v)) in enumerate(self.d.iteritems())]
+        self.d.update((e[1], e) for e in self.heap)
         heapify(self.heap)
 
     @doc(dict.clear)

--- a/heapdict.py
+++ b/heapdict.py
@@ -29,7 +29,7 @@ def heappop(heap, i=0):
     returnitem = heap[i]  # raises appropriate IndexError if invalid index.
     lastelt = heap.pop()
     # If we are not returning the last node, put it at i and sift it into place.
-    if lastlt is not returnitem:
+    if lastelt is not returnitem:
         _set(heap, i, lastelt)
         # if lastelt is greater than the previous node, move it down.
         if lastelt[0] > returnitem[0]:
@@ -154,7 +154,7 @@ d is returned if given, otherwise KeyError is raised"""
         if len(args) == 0:
             return self.popitem()[0]
         else:
-            return = super(heapdict, self).pop(*args)
+            return super(heapdict, self).pop(*args)
 
     def popitem(self):
         """D.popitem() -> (k, v), remove and return the (key, value) pair with lowest\nvalue; but raise KeyError if D is empty."""

--- a/heapdict.py
+++ b/heapdict.py
@@ -60,11 +60,10 @@ def _siftdown(heap, pos):
     while pos > 0:
         parentpos = (pos - 1) >> 1
         parent = heap[parentpos]
-        if newitem[0] < parent[0]:
-            _set(heap, pos, parent)
-            pos = parentpos
-            continue
-        break
+        if newitem[0] >= parent[0]:
+            break
+        _set(heap, pos, parent)
+        pos = parentpos
     _set(heap, pos, newitem)
 
 # 'heap' is a heap at all indicies > pos. 'pos' is the index of a node that may
@@ -80,13 +79,12 @@ def _siftup(heap, pos):
         if rightpos < endpos and heap[childpos][0] > heap[rightpos][0]:
             childpos = rightpos
         child = heap[childpos]
-        if newitem[0] > child[0]:
-            # Move the smaller child up.
-            _set(heap, pos, child)
-            pos = childpos
-            childpos = 2 * pos + 1
-            continue
-        break
+        if newitem[0] <= child[0]:
+            break
+        # Move the smaller child up.
+        _set(heap, pos, child)
+        pos = childpos
+        childpos = 2 * pos + 1
     # The node at pos is empty now, put newitem there.
     _set(heap, pos, newitem)
 

--- a/heapdict.py
+++ b/heapdict.py
@@ -34,8 +34,8 @@ def heappop(heap, i=0):
         # if lastelt is greater than the previous node, move it down.
         if lastelt[0] > returnitem[0]:
             _siftup(heap, i)
-        # if lastelt is smaller than the previous node, move it up.
-        elif lastelt[0] < returnitem[0]:
+        # otherwise it must be equal or smaller, move it up.
+        else:
             _siftdown(heap, i)
     return returnitem
 
@@ -114,15 +114,15 @@ class heapdict(collections.MutableMapping):
 
     @doc(dict.__setitem__)
     def __setitem__(self, key, value):
-        try:
+        if key in self.d:
             wrapper = self.d[key]
             oldvalue, _, i = wrapper
             wrapper[0] = value
             if oldvalue < value:
                 _siftup(self.heap, i)
-            elif value < oldvalue:
+            else:
                 _siftdown(self.heap, i)
-        except KeyError:
+        else:
             wrapper = [value, key, -2]
             self.d[key] = wrapper
             heappush(self.heap, wrapper)

--- a/heapdict.py
+++ b/heapdict.py
@@ -47,7 +47,7 @@ def heapify(heap):
     # or i < (n-1)/2.  If n is even = 2*j, this is (2*j-1)/2 = j-1/2 so
     # j-1 is the largest, which is n//2 - 1.  If n is odd = 2*j+1, this is
     # (2*j+1-1)/2 = j so j-1 is the largest, and that's again n//2-1.
-    for i in xrange(len(heap)//2 - 1, -1, -1):
+    for i in reversed(xrange(len(heap)//2)):
         _siftup(heap, i)
 
 

--- a/test_heap.py
+++ b/test_heap.py
@@ -20,12 +20,8 @@ class TestHeap(unittest.TestCase):
 
     def make_data(self):
         pairs = [(random.random(), random.random()) for i in range(N)]
-        h = heapdict()
-        d = {}
-        for k, v in pairs:
-            h[k] = v
-            d[k] = v
-
+        h = heapdict(pairs)
+        d = dict(pairs)
         pairs.sort(key=lambda x: x[1], reverse=True)
         return h, pairs, d
 


### PR DESCRIPTION
Change heappop() to support optional index of node to pop. Average O(1) for arbitrary indexes, worst-case O(ln(N)) for the top.  Simplify heapdict.__delitem__() use heappop() with an index.

Add heapify() for O(N) heap initialization. Use heapify() in heapdict.__init__() for faster O(N) heap initialization.

Change _shiftup() to not bubble all the way down to a leaf and then shift the node back up. This can double the number of compares, but reduces the number of shifts, and importantly short-circuits the search when changing node priorities by small amounts. For us priority compares are cheapish.

Change _shiftdown() to not take startpos argument, always bubbling all the way to the top of the heap if necessary. This is because _shiftup() no longer uses it to shift nodes partially back up the tree.

Remove obsolete _swap() and heapdict.__marker.

Change heapdict.__setitem__() to change existing entries values and sift them up/down as required instead of doing delete+add. This makes it average O(1), worst case O(ln(N)) for large changes in value.

Simplify heapdict.pop() to leverage of IndexErrors raised by heappop().